### PR TITLE
conform: fix checking of a custom data type

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -514,9 +514,9 @@ defmodule Conform.Translate do
       [{mod, args}]         -> {mod, args}
       mod                   -> {mod, nil}
     end
-    case Code.ensure_loaded(mod) do
-      {:error, :nofile} -> {false, mod, args}
-      {:module, mod}    ->
+    case Code.ensure_loaded?(mod) do
+      false -> {false, mod, args}
+      _    ->
         behaviours = get_in(mod.module_info, [:attributes, :behaviour]) || []
         case Enum.member?(behaviours, Conform.Type) do
           true  -> {true, mod, args}


### PR DESCRIPTION
A custom data type represented as a module name in the
conform schema. Previously we checked a type with the call of the
Code.ensure_loaded/1, but it returns {:error, :embedded} if an
application release launched in 'foreground' mode. The problem that
we can't load any modules in runtime if the erlang VM was launched
in embeded mode.

Now we are using Code.ensure_load?/1 which does not try to load a
given module, but just checks was it loaded or not.
