### PR TITLE
conform: fix is_custom_datatype?/1

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -510,6 +510,7 @@ defmodule Conform.Translate do
   defp is_custom_type?(datatype) do
     {mod, args} = case datatype do
       [{mod, args}]         -> {mod, args}
+      [mod]                 -> {mod, nil}
       mod                   -> {mod, nil}
     end
     case Code.ensure_loaded?(mod) do


### PR DESCRIPTION
Previously we checked a datatype from a schema that it is a custom
data type. But the previous code was wrong for the case when a
mapping has `[:complex]` datatype.

This patch fixes this.
