### PR TITLE
fix: Allow .*. at other than third position

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -247,13 +247,13 @@ defmodule Conform.Translate do
   defp update_complex_acc([], result, _, _), do: result
   defp update_complex_acc([{from_key, map} | mapping], result, translations, data) do
     to_key            = String.to_atom(Keyword.get(map, :to) <> ".*")
-    [app_name, path]  = Keyword.get(map, :to) |> String.split(".") |> Enum.map(&String.to_atom/1)
+    [app_name| path]  = Keyword.get(map, :to) |> String.split(".") |> Enum.map(&String.to_atom/1)
     built = build_complex(mapping, translations, data, from_key, to_key)
             |> List.flatten
             |> Enum.sort_by(fn k -> elem(k, 0) end)
     result = case result do
-      [] -> update_in!([], [app_name, path], built)
-      _  -> update_in!(result, [app_name, path], built)
+      [] -> update_in!([], [app_name| path], built)
+      _  -> update_in!(result, [app_name| path], built)
     end
     update_complex_acc(mapping, result, translations, data)
   end

--- a/test/confs/complex_example.conf
+++ b/test/confs/complex_example.conf
@@ -15,3 +15,8 @@ complex_another_list.second.dbid = 1
 
 sublist_example.opt1 = val1
 sublist_example."opt-2" = val2
+
+complex.a.deep.list.first.id = 100
+complex.a.deep.list.first.username = "test_deep_username1"
+complex.a.deep.list.second.id = 200
+complex.a.deep.list.second.username = "test_deep_username2"

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -75,14 +75,18 @@ defmodule IntegrationTest do
     conf   = Path.join(["test", "confs", "complex_example.conf"]) |> Conform.Parse.file!
     schema = Path.join(["test", "schemas", "complex_schema.exs"]) |> Conform.Schema.load
     effective = Conform.Translate.to_config([], conf, schema)
-    expected = [my_app:
-                [complex_another_list:
-                 [first: %{id: 100, dbid: 1, age: 20, username: "test_username1"},
-                  second: %{id: 101, dbid: 1, age: 40, username: "test_username2"}],
-                 complex_list: [
-                   buzz: %{age: 25, type: :person}, fido: %{age: 30, type: :dog}],
-                 some_val: :foo, some_val2: 2.5,
-                 sublist: ["opt-2": "val2", opt1: "val1"]]]
+    expected = [my_app: [
+                  a: [deep: [list: [
+                    first:  %{id: 100, username: "test_deep_username1"},
+                    second: %{id: 200, username: "test_deep_username2"}]]],
+                  complex_another_list: [
+                    first:  %{id: 100, dbid: 1, age: 20, username: "test_username1"},
+                    second: %{id: 101, dbid: 1, age: 40, username: "test_username2"}],
+                  complex_list: [
+                    buzz: %{age: 25, type: :person},
+                    fido: %{age: 30, type: :dog}],
+                  some_val: :foo, some_val2: 2.5,
+                  sublist: ["opt-2": "val2", opt1: "val1"]]]
 
     assert effective == expected
   end

--- a/test/schemas/complex_schema.exs
+++ b/test/schemas/complex_schema.exs
@@ -46,6 +46,24 @@
       datatype: :integer,
       default: 30
     ],
+    #
+    # deep complex
+    #
+    "complex.a.deep.list.*": [
+      to: "my_app.a.deep.list",
+      datatype: [:complex],
+      default: []
+    ],
+    "complex.a.deep.list.*.id": [
+      to: "my_app.a.deep.list",
+      datatype: :integer,
+      default:  0
+    ],
+    "complex.a.deep.list.*.username": [
+      to: "my_app.a.deep.list",
+      datatype: :binary,
+      default: ""
+    ],
     # dynamic keyword list
     "sublist_example.*": [
       to: "my_app.sublist",
@@ -87,6 +105,14 @@
 
     "my_app.sublist.*": fn _, {key, value_map}, acc ->
       [{key, value_map[key]}|acc]
+    end,
+
+    "my_app.a.deep.list.*": fn _, {key, value_map}, acc ->
+      [{key, %{
+        id:       value_map[:id],
+        username: value_map[:username]
+       }} | acc]
     end
+
   ]
 ]


### PR DESCRIPTION
With the old version a star could only be used at third position (e.g. `app.module.*.id`)
With the new version a star is also allowed at other positions (e.g. `app.module.part.*.id`)
